### PR TITLE
the connectivity receiver was removed, because after android N we can…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,13 +23,6 @@
 
         <activity android:name=".ui.person.AddPerson"/>
 
-        <receiver android:name=".ConnectivityReceiver">
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
-                <action android:name="android.net.wifi.WIFI_STATE_CHANGED"/>
-                <action android:name="android.net.wifi.STATE_CHANGED"/>
-            </intent-filter>
-        </receiver>
     </application>
 
 </manifest>


### PR DESCRIPTION
…not setup a receiver from the manifest